### PR TITLE
REST API IP address for notification callback registration

### DIFF
--- a/8dev_restapi.js
+++ b/8dev_restapi.js
@@ -4,6 +4,7 @@ const EventEmitter = require('events');
 const rest = require('node-rest-client');
 const express = require('express');
 const parser = require('body-parser');
+const ip = require('ip');
 
 class Endpoint extends EventEmitter {
   constructor(service, id) {
@@ -138,6 +139,7 @@ class Service extends EventEmitter {
       port: 5728,
     };
     this.configure(opts);
+    this.ipAddress = ip.address();
     this.client = new rest.Client();
     this.endpoints = [];
     this.addTlvSerializer();
@@ -196,7 +198,7 @@ class Service extends EventEmitter {
   registerNotificationCallback() {
     return new Promise((fulfill, reject) => {
       const data = {
-        url: `http://localhost:${this.config.port}/notification`,
+        url: `http://${this.ipAddress}:${this.config.port}/notification`,
         headers: {},
       };
       const type = 'application/json';

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "body-parser": "^1.18.2",
     "coap": "^0.21.0",
     "express": "^4.16.3",
+    "ip": "^1.1.5",
     "node-rest-client": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
*Added node module which helps retrieving ip address in local network.
*This ip address is used in notification callback registration in order to show REST server where to send notifications.