### PR TITLE
Changed deleteNotificationCallback and cancelObserve functions:

### DIFF
--- a/8dev_restapi.js
+++ b/8dev_restapi.js
@@ -173,22 +173,19 @@ class Service extends EventEmitter {
   }
 
   stop() {
-    return new Promise((fulfill, reject) => {
-      if (this.server !== undefined) {
-        this.server.close();
-        this.server = undefined;
-        this.deleteNotificationCallback().then(() => {
-          fulfill();
-        }).catch((err) => {
-          reject(err);
-        });
-      }
-      if (this.pollTimer !== undefined) {
-        clearInterval(this.pollTimer);
-        this.pollTimer = undefined;
-        fulfill();
-      }
-    });
+    const promises = [];
+
+    if (this.server !== undefined) {
+      this.server.close();
+      this.server = undefined;
+      promises.push(this.deleteNotificationCallback());
+    }
+    if (this.pollTimer !== undefined) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = undefined;
+    }
+
+    return Promise.all(promises);
   }
 
   createServer() {

--- a/8dev_restapi.js
+++ b/8dev_restapi.js
@@ -116,11 +116,10 @@ class Endpoint extends EventEmitter {
   cancelObserve(path) {
     return new Promise((fulfill, reject) => {
       this.service.delete(`/subscriptions/${this.id}${path}`).then((dataAndResponse) => {
-        if (dataAndResponse.resp.statusCode === 204) {
-          fulfill(dataAndResponse.data);
-        } else {
-          reject(dataAndResponse.resp.statusCode);
-        }
+        // Promise is fulfilled with any status code.
+        // 204 means observation will be succesfully cancelled.
+        // 404 means observation will not be deleted because it was not registered or found.
+        fulfill(dataAndResponse.resp.statusCode);
       }).catch((err) => {
         reject(err);
       });

--- a/tests/rest-api.test.js
+++ b/tests/rest-api.test.js
@@ -222,26 +222,16 @@ describe('Rest API interface', () => {
     });
 
     describe('cancelObserve function', () => {
-      it('should return an object with empty buffer', () => {
+      it('should return status code if connection is successful', () => {
         nock(url)
           .delete(`/subscriptions/${deviceName}${path}`)
           .reply(204, response.deleteCallback);
         return device.cancelObserve(path).then((resp) => {
-          expect(typeof resp).to.equal('object');
-          expect(resp.length).to.equal(0);
+          expect(typeof resp).to.equal('number');
         });
       });
 
-      it('should return an error (status code number) if status code is not 204', () => {
-        nock(url)
-          .delete(`/subscriptions/${deviceName}${path}`)
-          .reply(404);
-        return device.cancelObserve(path).catch((err) => {
-          expect(typeof err).to.equal('number');
-        });
-      });
-
-      it('should return rejected promise with exception object if connection is not succesfull', (done) => {
+      it('should return rejected promise with exception object if connection is not successful', (done) => {
         device.cancelObserve(path)
           .catch((err) => {
             expect(typeof err).to.equal('object');

--- a/tests/rest-api.test.js
+++ b/tests/rest-api.test.js
@@ -395,26 +395,16 @@ describe('Rest API interface', () => {
     });
 
     describe('deleteNotificationCallback function', () => {
-      it('should return an object with empty buffer', () => {
+      it('should return status code if connection is successful', () => {
         nock(url)
           .delete('/notification/callback')
           .reply(204, response.deleteCallback);
         return service.deleteNotificationCallback().then((resp) => {
-          expect(typeof resp).to.equal('object');
-          expect(resp.length).to.equal(0);
+          expect(typeof resp).to.equal('number');
         });
       });
 
-      it('should return an error (status code number) if status code is not 204', () => {
-        nock(url)
-          .delete('/notification/callback')
-          .reply(404);
-        return service.deleteNotificationCallback().catch((err) => {
-          expect(typeof err).to.equal('number');
-        });
-      });
-
-      it('should return rejected promise with exception object if connection is not succesfull', (done) => {
+      it('should return rejected promise with exception object if connection is not successful', (done) => {
         service.deleteNotificationCallback()
           .catch((err) => {
             expect(typeof err).to.equal('object');


### PR DESCRIPTION
* Promise which is returned resolves with any status code. This was made by the fact that for instace status code 404 does not mean an error, it means that the observation could not be deleted because it was not found or registered.