### PR TITLE
Prevent client from deregistering multiple times

### DIFF
--- a/8dev_emulate/nodes/clientNodeInstance.js
+++ b/8dev_emulate/nodes/clientNodeInstance.js
@@ -800,6 +800,7 @@ class ClientNodeInstance extends EventEmitter {
     return new Promise((started, failed) => {
       this.register(registrationPath)
         .then((updatesPath) => {
+          this.removeAllListeners('deregister');
           this.on('deregister', () => {
             this.deregistrationHandle(updatesPath);
           });


### PR DESCRIPTION
In `class ClientNodeInstance` every call to `start()` triggers `startRegistration` which registers a callback for event `'deregister'`. If `start()` is called multiple times, later calling `stop()` triggers `'deregister'` event multiple times as well. This is a possible solution to this problem, but is not necessarily the optimal one.